### PR TITLE
Simple input validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,17 +54,22 @@
     }
 
 
-    TagsInput.prototype.anyErrors = function(string){
-        if( this.options.max != null && this.arr.length >= this.options.max ){
-            console.log('max tags limit reached');
+    TagsInput.prototype.anyErrors = function (string) {
+        if (this.options.max != null && this.arr.length >= this.options.max) {
+            console.error('max tags limit reached');
             return true;
         }
-        
-        if(!this.options.duplicate && this.arr.indexOf(string) != -1 ){
-            console.log('duplicate found " '+string+' " ')
+    
+        if (!this.options.duplicate && this.arr.indexOf(string) != -1) {
+            console.error('duplicate found " ' + string + ' " ')
             return true;
         }
-
+    
+        if (this.options.validator != undefined && !this.options.validator(string)) {
+            console.error('Invalid input: ' + string)
+            return true;
+        }
+    
         return false;
     }
 


### PR DESCRIPTION
The following changes add a simple way to use input validation on any tag. They can be used in the following way:


```
var emails = new TagsInput({
            selector: 'email-input',
            duplicate: false,
            max: 10,
            validator: (input) => {
                return utils.validateEmail(input)
            }
        });
```

The user simply needs to provide a validation function which returns a boolean. 

Furthermore I changed the console.log to console.error which seem more appropriate for an error.