### PR TITLE
fix key events

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@
             var str = tags.input.value.trim(); 
             if( !!(~[9 , 13 , 188].indexOf( e.keyCode ))  )
             {
+                e.preventDefault();
                 tags.input.value = "";
                 if(str != "")
                     tags.addTag(str);


### PR DESCRIPTION
`Tab` key press was focusing on next input, `,` (comma) key press was leaving a comma on Tags Input, and `Enter` keypress was trying to submit when Tags input used in a form. I just added preventing default behavior on keydown event of these.
